### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Quick Start
 
 Clone the repository:
 ```
-git clone [https://github.com/hsr88/log-voyager.git](https://github.com/hsr88/log-voyager.git)
+git clone https://github.com/hsr88/log-voyager.git
 cd log-voyager
 ```
 


### PR DESCRIPTION
Fix wrong URL to clone

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the README clone command by replacing the markdown link with a plain URL so copy-paste works and the repo clones correctly.

<sup>Written for commit 2f12d0b1175eff282eefe0768fb3f8d007542d28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

